### PR TITLE
Fix security module pot string

### DIFF
--- a/po/template.pot
+++ b/po/template.pot
@@ -999,8 +999,7 @@ msgid "Fix MacOS drivers"
 msgstr ""
 
 msgid ""
-"Which security module is now used by default in new openSUSE Tumbleweed and "
-"Leap 16.0 installations?"
+"Which security module is now used by default in new openSUSE Tumbleweed and Leap 16.0 installations?"
 msgstr ""
 
 #. no-translate


### PR DESCRIPTION
It was accidentally split on two lines