### PR TITLE
Remove references from result rather than replace value

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -81,7 +81,8 @@ function saveResultsToFile() {
 
 // Function to clear results
 function clearResults() {
-  results = {};
+  // results = {} would not update references in router.js etc
+  for (const key in results) delete results[key];
   if (consts.STATS_MODE === "STATS_FILE") {
     saveResultsToFile();
   }


### PR DESCRIPTION
Assigning results = {} would not update references in router.js etc so we really have to remove individual references.