### PR TITLE
Update Dockerfile-Production with --maxconnects

### DIFF
--- a/Dockerfile-Production
+++ b/Dockerfile-Production
@@ -3,9 +3,8 @@ FROM registry.opensuse.org/opensuse/infrastructure/images/bci/containers/bci-nod
 WORKDIR /opt/quiz
 COPY . .
 RUN \
-        # Fix issue with npm error EMFILE: too many open files in cache
-        RUN ulimit -n 65535 || true
-	npm clean-install --omit=dev && \
+        # --maxsockets should fix issue with npm error EMFILE: too many open files in cache
+	npm clean-install --omit=dev --maxsockets 50 && \
 	npm run build:css && \
 	rm -r /var/{cache,log}/* && \
 	useradd -mU quiz


### PR DESCRIPTION
Should fix

```
Jul 10 11:02:02 quiz quiz-update[31167]: STEP 4/6: RUN         npm clean-install --omit=dev &&         npm run build:css &&         rm -r /var/{cache,log}/* &&         useradd -mU quiz
Jul 10 11:02:02 quiz quiz-update[31167]: npm error code EMFILE
Jul 10 11:02:02 quiz quiz-update[31167]: npm error syscall open
Jul 10 11:02:02 quiz quiz-update[31167]: npm error path /root/.npm/_cacache/index-v5/34/cb/dd5e6f02ebea3574006624e5dd81e72b124d66a1bd1598ab078fda7118f7
Jul 10 11:02:02 quiz quiz-update[31167]: npm error errno -24
Jul 10 11:02:02 quiz quiz-update[31167]: npm error EMFILE: too many open files, open '/root/.npm/_cacache/index-v5/34/cb/dd5e6f02ebea3574006624e5dd81e72b124d66a1bd1598ab078fda7118f7'
```