### PR TITLE
SUSE instances uses SUSE theme and suse+openssl quiz

### DIFF
--- a/instances.json
+++ b/instances.json
@@ -15,6 +15,12 @@
 	    "theme": "SUSE",
     },
     "linuxdays": {},
-    "suse": {},
+    "suse": {
+	    "quizzes": [
+		    "suse",
+		    "suse_openssl",
+	    ],
+	    "theme": "SUSE",
+    },
   }
 }


### PR DESCRIPTION
Let's keep it open, until we verify that test instance has configuration from #175 

<img width="1256" height="1242" alt="image" src="https://github.com/user-attachments/assets/c805a252-39ba-487c-ac26-f36034e7798a" />
