### PR TITLE
Fix Indonesian language name in dropdown (#129)

### DIFF
--- a/src/i18nHelpers.js
+++ b/src/i18nHelpers.js
@@ -57,7 +57,7 @@ function getAvailableLanguages(poDirPath) {
     es: "Español",
     he: "עברית",
     hi: "हिन्दी",
-    id: "Indonesia",
+    id: "Bahasa Indonesia",
     ja: "日本語",
     nl: "Nederlands",
     pl: "Polski",


### PR DESCRIPTION
Fix incorrect language name for Indonesian (closes #129)

"id" was displaying as "Indonesia" (a country name) in the 
language dropdown. Corrected to "Bahasa Indonesia" — the proper 
native name for Indonesian, consistent with the convention used 
by all other entries in the map (e.g. Türkçe, Українська).