### PR TITLE
Rename key 'linuxdays.cz' to 'linuxdays'

### DIFF
--- a/instances.json
+++ b/instances.json
@@ -79,7 +79,7 @@
 		],
 		"theme": "openSUSE",
 	},
-	"linuxdays.cz": {
+	"linuxdays": {
 	    "quizzes": [
 	        "arm",
 	        "immutability",


### PR DESCRIPTION
dns only works for one layer, not for two